### PR TITLE
created quick registration card

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,19 @@
-import React from 'react';
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Navigate,
-} from "react-router-dom";
-import AdminLoginPage from "./pages/AdminLogin";
-import EventsPage from './pages/Events';
-import ManageEvent from './pages/ManageEvent';
-import AttendeeList from './pages/AttendeeList';
-import PasscodeManagement from './pages/PasscodeManagement';
-import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
-import "./App.css";
-import ProtectedRoute from "./components/auth/protectedRoute";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom"
+import AdminLoginPage from "./pages/AdminLogin"
+import EventsPage from "./pages/Events"
+import ManageEvent from "./pages/ManageEvent"
+import AttendeeList from "./pages/AttendeeList"
+import QuickRegistrationsList from "./pages/QuickRegistrationsList"
+import PasscodeManagement from "./pages/PasscodeManagement"
+import { ToastContainer } from "react-toastify"
+import "react-toastify/dist/ReactToastify.css"
+import "./App.css"
+import ProtectedRoute from "./components/auth/protectedRoute"
 
 function App() {
   return (
     <Router>
-      <ToastContainer 
+      <ToastContainer
         position="top-right"
         autoClose={3000}
         hideProgressBar={false}
@@ -29,7 +24,7 @@ function App() {
         draggable
         pauseOnHover
         theme="colored"
-        style={{ top: '60px' }} // Add this to position it below headers
+        style={{ top: "60px" }} // Add this to position it below headers
         className="toastify-container" // Add a custom class for targeting in CSS
       />
       <Routes>
@@ -45,7 +40,7 @@ function App() {
             </ProtectedRoute>
           }
         />
-        
+
         <Route
           path="/events/:eventId"
           element={
@@ -54,7 +49,7 @@ function App() {
             </ProtectedRoute>
           }
         />
-        
+
         <Route
           path="/events/:eventId/attendees/:type"
           element={
@@ -63,7 +58,16 @@ function App() {
             </ProtectedRoute>
           }
         />
-        
+
+        <Route
+          path="/events/:eventId/quick-registrations"
+          element={
+            <ProtectedRoute>
+              <QuickRegistrationsList />
+            </ProtectedRoute>
+          }
+        />
+
         <Route
           path="/events/:eventId/passcodes"
           element={
@@ -78,7 +82,7 @@ function App() {
         <Route path="*" element={<Navigate replace to="/events" />} />
       </Routes>
     </Router>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/components/event/EventMetricsSection.jsx
+++ b/src/components/event/EventMetricsSection.jsx
@@ -1,22 +1,37 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { 
-  faChartLine, 
-  faUsers, 
-  faUserCheck, 
+"use client"
+import { useNavigate } from "react-router-dom"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+  faChartLine,
+  faUsers,
+  faUserCheck,
   faUserClock,
   faEye,
-  faArrowRight
-} from '@fortawesome/free-solid-svg-icons';
+  faArrowRight,
+  faUserPlus,
+} from "@fortawesome/free-solid-svg-icons"
+import { useState, useEffect } from "react"
 
 const EventMetricsSection = ({ metrics, eventId }) => {
-  const navigate = useNavigate();
-  
+  const navigate = useNavigate()
+  // State to store the dummy quick registrations count
+  const [quickRegCount, setQuickRegCount] = useState(0)
+
+  // Generate a random number of quick registrations on component mount
+  useEffect(() => {
+    // Generate a random number between 25-50
+    const randomCount = Math.floor(25 + Math.random() * 25)
+    setQuickRegCount(randomCount)
+  }, [])
+
   const navigateToAttendees = (type) => {
-    navigate(`/events/${eventId}/attendees/${type}`);
-  };
-  
+    navigate(`/events/${eventId}/attendees/${type}`)
+  }
+
+  const navigateToQuickRegistrations = () => {
+    navigate(`/events/${eventId}/quick-registrations`)
+  }
+
   return (
     <section className="metrics-section">
       <div className="section-header">
@@ -24,7 +39,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
           <FontAwesomeIcon icon={faChartLine} /> Metrics & Analytics
         </h2>
       </div>
-      
+
       <div className="metrics-grid">
         <div className="metric-card">
           <div className="metric-icon">
@@ -35,9 +50,9 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             <p className="metric-description">Total number of users who registered for this event</p>
             <div className="metric-value">{metrics.totalRegistered}</div>
           </div>
-          <button 
+          <button
             className="metrics-view-button"
-            onClick={() => navigateToAttendees('registered')}
+            onClick={() => navigateToAttendees("registered")}
             aria-label="View registered attendees"
           >
             <span className="view-text">
@@ -48,7 +63,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             </span>
           </button>
         </div>
-        
+
         <div className="metric-card">
           <div className="metric-icon online">
             <FontAwesomeIcon icon={faUserCheck} />
@@ -58,9 +73,9 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             <p className="metric-description">Attendees who participated remotely via stream</p>
             <div className="metric-value">{metrics.totalAttendedOnline}</div>
           </div>
-          <button 
+          <button
             className="metrics-view-button"
-            onClick={() => navigateToAttendees('online')}
+            onClick={() => navigateToAttendees("online")}
             aria-label="View online attendees"
           >
             <span className="view-text">
@@ -71,7 +86,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             </span>
           </button>
         </div>
-        
+
         <div className="metric-card">
           <div className="metric-icon offline">
             <FontAwesomeIcon icon={faUserCheck} />
@@ -81,9 +96,9 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             <p className="metric-description">Attendees who participated at the physical venue</p>
             <div className="metric-value">{metrics.totalAttendedOffline}</div>
           </div>
-          <button 
+          <button
             className="metrics-view-button"
-            onClick={() => navigateToAttendees('offline')}
+            onClick={() => navigateToAttendees("offline")}
             aria-label="View onsite attendees"
           >
             <span className="view-text">
@@ -94,7 +109,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             </span>
           </button>
         </div>
-        
+
         <div className="metric-card">
           <div className="metric-icon both">
             <FontAwesomeIcon icon={faUserCheck} />
@@ -104,9 +119,9 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             <p className="metric-description">Attendees who participated both online and onsite</p>
             <div className="metric-value">{metrics.totalAttendedBoth}</div>
           </div>
-          <button 
+          <button
             className="metrics-view-button"
-            onClick={() => navigateToAttendees('both')}
+            onClick={() => navigateToAttendees("both")}
             aria-label="View hybrid attendees"
           >
             <span className="view-text">
@@ -117,7 +132,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             </span>
           </button>
         </div>
-        
+
         <div className="metric-card">
           <div className="metric-icon absent">
             <FontAwesomeIcon icon={faUserClock} />
@@ -127,9 +142,9 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             <p className="metric-description">Registered users who did not attend the event</p>
             <div className="metric-value">{metrics.totalDidNotAttend}</div>
           </div>
-          <button 
+          <button
             className="metrics-view-button"
-            onClick={() => navigateToAttendees('absent')}
+            onClick={() => navigateToAttendees("absent")}
             aria-label="View absent registrants"
           >
             <span className="view-text">
@@ -140,9 +155,33 @@ const EventMetricsSection = ({ metrics, eventId }) => {
             </span>
           </button>
         </div>
+
+        {/* New Quick Registrations Card with dummy data */}
+        <div className="metric-card">
+          <div className="metric-icon quick-reg">
+            <FontAwesomeIcon icon={faUserPlus} />
+          </div>
+          <div className="metric-content">
+            <h3>Quick Registrations</h3>
+            <p className="metric-description">Users who registered with minimal information</p>
+            <div className="metric-value">{quickRegCount}</div>
+          </div>
+          <button
+            className="metrics-view-button"
+            onClick={navigateToQuickRegistrations}
+            aria-label="View quick registrations"
+          >
+            <span className="view-text">
+              <FontAwesomeIcon icon={faEye} /> View Registrations
+            </span>
+            <span className="view-arrow">
+              <FontAwesomeIcon icon={faArrowRight} />
+            </span>
+          </button>
+        </div>
       </div>
     </section>
-  );
-};
+  )
+}
 
-export default EventMetricsSection;
+export default EventMetricsSection

--- a/src/pages/QuickRegistrationsList.jsx
+++ b/src/pages/QuickRegistrationsList.jsx
@@ -1,0 +1,371 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useParams, useNavigate } from "react-router-dom"
+import { useSelector } from "react-redux"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+  faArrowLeft,
+  faUserPlus,
+  faSearch,
+  faTimes,
+  faUser,
+  faEnvelope,
+  faPhone,
+  faVenus,
+  faMars,
+  faLock,
+  faFilter,
+  faChevronDown,
+} from "@fortawesome/free-solid-svg-icons"
+import Pagination from "../components/Pagination"
+import "../stylesheets/attendeeList.css"
+import "../stylesheets/QuickRegistrations.css"
+
+// Make sure the generateDummyQuickRegistrations function includes registration dates
+const generateDummyQuickRegistrations = (count) => {
+  const genders = ["Male", "Female"]
+  const registrations = []
+
+  for (let i = 1; i <= count; i++) {
+    const gender = genders[Math.floor(Math.random() * genders.length)]
+
+    // Generate a random date within the last 30 days
+    const randomDaysAgo = Math.floor(Math.random() * 30)
+    const registrationDate = new Date()
+    registrationDate.setDate(registrationDate.getDate() - randomDaysAgo)
+
+    registrations.push({
+      id: i,
+      name: `Quick User ${i}`,
+      email: `quick${i}@example.com`,
+      phone: `+1 555-${String(i).padStart(3, "0")}-${Math.floor(1000 + Math.random() * 9000)}`,
+      gender,
+      otp: Math.floor(100000 + Math.random() * 900000).toString(), // 6-digit OTP
+      registrationDate: registrationDate.toISOString(),
+    })
+  }
+
+  return registrations
+}
+
+const QuickRegistrationsList = () => {
+  const { eventId } = useParams()
+  const navigate = useNavigate()
+
+  // Get event data from Redux store
+  const { events } = useSelector((state) => state.events)
+
+  // Local state
+  const [quickRegistrations, setQuickRegistrations] = useState([])
+  const [filteredRegistrations, setFilteredRegistrations] = useState([])
+  const [displayedRegistrations, setDisplayedRegistrations] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [searchTerm, setSearchTerm] = useState("")
+  const [eventName, setEventName] = useState("Event Name")
+  const [filterActive, setFilterActive] = useState(false)
+
+  // Filter state
+  const [filters, setFilters] = useState({
+    gender: "all",
+    dateRange: "all",
+  })
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1)
+  const [itemsPerPage, setItemsPerPage] = useState(12)
+  const [totalPages, setTotalPages] = useState(1)
+
+  // Load dummy data and event name when component mounts
+  useEffect(() => {
+    // Find event name from events array
+    const currentEvent = events.find((event) => event.id === eventId)
+    if (currentEvent) {
+      setEventName(currentEvent.name)
+    }
+
+    // Generate dummy data (between 25-50 registrations)
+    const dummyCount = Math.floor(25 + Math.random() * 25)
+    const dummyData = generateDummyQuickRegistrations(dummyCount)
+    setQuickRegistrations(dummyData)
+    setLoading(false)
+  }, [eventId, events])
+
+  // Filter registrations based on search term and filters
+  useEffect(() => {
+    if (quickRegistrations.length) {
+      const filtered = quickRegistrations.filter((reg) => {
+        // Text search filter
+        const searchMatch =
+          searchTerm === "" ||
+          (reg.name && reg.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
+          (reg.email && reg.email.toLowerCase().includes(searchTerm.toLowerCase())) ||
+          (reg.phone && reg.phone.toLowerCase().includes(searchTerm.toLowerCase()))
+
+        // Gender filter
+        const genderMatch = filters.gender === "all" || reg.gender === filters.gender
+
+        // Date range filter
+        let dateMatch = true
+        const regDate = new Date(reg.registrationDate)
+        const today = new Date()
+
+        if (filters.dateRange === "today") {
+          const todayStart = new Date(today.setHours(0, 0, 0, 0))
+          dateMatch = regDate >= todayStart
+        } else if (filters.dateRange === "yesterday") {
+          const yesterdayStart = new Date(today)
+          yesterdayStart.setDate(yesterdayStart.getDate() - 1)
+          yesterdayStart.setHours(0, 0, 0, 0)
+
+          const yesterdayEnd = new Date(today)
+          yesterdayEnd.setDate(yesterdayEnd.getDate() - 1)
+          yesterdayEnd.setHours(23, 59, 59, 999)
+
+          dateMatch = regDate >= yesterdayStart && regDate <= yesterdayEnd
+        } else if (filters.dateRange === "last7days") {
+          const last7Days = new Date(today)
+          last7Days.setDate(last7Days.getDate() - 7)
+          dateMatch = regDate >= last7Days
+        } else if (filters.dateRange === "last30days") {
+          const last30Days = new Date(today)
+          last30Days.setDate(last30Days.getDate() - 30)
+          dateMatch = regDate >= last30Days
+        }
+
+        return searchMatch && genderMatch && dateMatch
+      })
+
+      setFilteredRegistrations(filtered)
+      setTotalPages(Math.ceil(filtered.length / itemsPerPage))
+      setCurrentPage(1) // Reset to first page when filters change
+    } else {
+      setFilteredRegistrations([])
+      setTotalPages(0)
+    }
+  }, [quickRegistrations, searchTerm, filters, itemsPerPage])
+
+  // Update displayed registrations when page changes or filtered results change
+  useEffect(() => {
+    if (filteredRegistrations.length) {
+      const startIndex = (currentPage - 1) * itemsPerPage
+      const endIndex = Math.min(startIndex + itemsPerPage, filteredRegistrations.length)
+      setDisplayedRegistrations(filteredRegistrations.slice(startIndex, endIndex))
+    } else {
+      setDisplayedRegistrations([])
+    }
+  }, [currentPage, filteredRegistrations, itemsPerPage])
+
+  const handleBack = () => {
+    navigate(`/events/${eventId}`)
+  }
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page)
+    // Scroll to top of the list
+    document.querySelector(".quick-reg-content")?.scrollIntoView({ behavior: "smooth" })
+  }
+
+  const handleItemsPerPageChange = (newItemsPerPage) => {
+    setItemsPerPage(newItemsPerPage)
+  }
+
+  const toggleFilter = () => {
+    setFilterActive(!filterActive)
+  }
+
+  const handleFilterChange = (filterName, value) => {
+    setFilters((prev) => ({
+      ...prev,
+      [filterName]: value,
+    }))
+  }
+
+  const clearFilters = () => {
+    setFilters({
+      gender: "all",
+      dateRange: "all",
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="attendee-list-page">
+        <div className="loading-container">
+          <div className="spinner"></div>
+          <p>Loading quick registrations...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="attendee-list-page">
+      <div className="attendee-list-container">
+        <div className="attendee-list-header">
+          <button className="back-button" onClick={handleBack} aria-label="Back to event">
+            <FontAwesomeIcon icon={faArrowLeft} />
+          </button>
+
+          <div className="header-content">
+            <h1>
+              <FontAwesomeIcon icon={faUserPlus} /> Quick Registrations
+              <span className="attendee-count">{filteredRegistrations.length}</span>
+            </h1>
+            <p className="event-name">{eventName}</p>
+          </div>
+        </div>
+
+        <div className="search-container">
+          <div className="search-input-container">
+            <FontAwesomeIcon icon={faSearch} className="search-icon" />
+            <input
+              type="text"
+              placeholder="Search by name, email or phone..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="search-input"
+            />
+            {searchTerm && (
+              <button className="clear-search-button" onClick={() => setSearchTerm("")} aria-label="Clear search">
+                <FontAwesomeIcon icon={faTimes} />
+              </button>
+            )}
+          </div>
+
+          <button className={`filter-button ${filterActive ? "active" : ""}`} onClick={toggleFilter}>
+            <FontAwesomeIcon icon={faFilter} />
+            <span>Filter</span>
+            {(filters.gender !== "all" || filters.dateRange !== "all") && <span className="filter-badge"></span>}
+          </button>
+        </div>
+
+        {filterActive && (
+          <div className="filter-panel">
+            <div className="filter-panel-content">
+              <div className="filter-group">
+                <label>Gender</label>
+                <div className="select-wrapper">
+                  <select value={filters.gender} onChange={(e) => handleFilterChange("gender", e.target.value)}>
+                    <option value="all">All</option>
+                    <option value="Male">Male</option>
+                    <option value="Female">Female</option>
+                  </select>
+                  <FontAwesomeIcon icon={faChevronDown} className="select-icon" />
+                </div>
+              </div>
+
+              <div className="filter-group">
+                <label>Registration Date</label>
+                <div className="select-wrapper">
+                  <select value={filters.dateRange} onChange={(e) => handleFilterChange("dateRange", e.target.value)}>
+                    <option value="all">All Time</option>
+                    <option value="today">Today</option>
+                    <option value="yesterday">Yesterday</option>
+                    <option value="last7days">Last 7 Days</option>
+                    <option value="last30days">Last 30 Days</option>
+                  </select>
+                  <FontAwesomeIcon icon={faChevronDown} className="select-icon" />
+                </div>
+              </div>
+            </div>
+
+            <div className="filter-actions">
+              <button className="clear-filters-button" onClick={clearFilters}>
+                <FontAwesomeIcon icon={faTimes} />
+                Clear Filters
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="quick-reg-content">
+          {filteredRegistrations.length > 0 ? (
+            <>
+              <div className="quick-reg-grid">
+                {displayedRegistrations.map((registration) => (
+                  <div key={registration.id} className="quick-reg-card">
+                    <div className="quick-reg-header">
+                      <h3 className="quick-reg-name">
+                        <FontAwesomeIcon icon={faUser} className="icon-primary" />
+                        {registration.name}
+                      </h3>
+                    </div>
+
+                    <div className="quick-reg-details">
+                      <div className="quick-reg-item">
+                        <div className="quick-reg-label">
+                          <FontAwesomeIcon icon={faEnvelope} />
+                          <span>Email:</span>
+                        </div>
+                        <div className="quick-reg-value">{registration.email || "N/A"}</div>
+                      </div>
+
+                      <div className="quick-reg-item">
+                        <div className="quick-reg-label">
+                          <FontAwesomeIcon icon={faPhone} />
+                          <span>Phone:</span>
+                        </div>
+                        <div className="quick-reg-value">{registration.phone || "N/A"}</div>
+                      </div>
+
+                      <div className="quick-reg-item">
+                        <div className="quick-reg-label">
+                          <FontAwesomeIcon icon={registration.gender === "Male" ? faMars : faVenus} />
+                          <span>Gender:</span>
+                        </div>
+                        <div className="quick-reg-value">{registration.gender || "N/A"}</div>
+                      </div>
+
+                      <div className="quick-reg-item">
+                        <div className="quick-reg-label">
+                          <FontAwesomeIcon icon={faLock} />
+                          <span>OTP:</span>
+                        </div>
+                        <div className="quick-reg-value otp-value">{registration.otp || "N/A"}</div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {filteredRegistrations.length > itemsPerPage && (
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  onPageChange={handlePageChange}
+                  itemsPerPage={itemsPerPage}
+                  onItemsPerPageChange={handleItemsPerPageChange}
+                />
+              )}
+            </>
+          ) : (
+            <div className="no-results">
+              <FontAwesomeIcon icon={faUserPlus} size="3x" style={{ opacity: 0.3, marginBottom: "1rem" }} />
+              <p>
+                No quick registrations found
+                {searchTerm || filters.gender !== "all" || filters.dateRange !== "all"
+                  ? " matching your search criteria"
+                  : ""}
+                .
+              </p>
+              {(searchTerm || filters.gender !== "all" || filters.dateRange !== "all") && (
+                <button
+                  className="clear-filters-button"
+                  onClick={() => {
+                    setSearchTerm("")
+                    clearFilters()
+                  }}
+                >
+                  Clear all filters
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default QuickRegistrationsList

--- a/src/stylesheets/QuickRegistrations.css
+++ b/src/stylesheets/QuickRegistrations.css
@@ -1,0 +1,140 @@
+/* Quick Registrations Styles */
+.quick-reg-content {
+    padding: 20px 30px;
+  }
+  
+  .quick-reg-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+  }
+  
+  .quick-reg-card {
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border: 1px solid #eaeaea;
+  }
+  
+  .quick-reg-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  }
+  
+  .quick-reg-header {
+    padding: 16px;
+    background-color: #f8f9fa;
+    border-bottom: 1px solid #eee;
+  }
+  
+  .quick-reg-name {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 18px;
+    font-weight: 600;
+    color: #333;
+  }
+  
+  .quick-reg-details {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  
+  .quick-reg-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  
+  .quick-reg-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: #555;
+    font-size: 14px;
+  }
+  
+  .quick-reg-value {
+    padding-left: 24px;
+    color: #333;
+    font-size: 15px;
+    word-break: break-word;
+  }
+  
+  .otp-value {
+    font-family: monospace;
+    letter-spacing: 1px;
+    font-weight: 600;
+    color: #e65100;
+  }
+  
+  /* Metric card styling for quick registrations */
+  .metric-icon.quick-reg {
+    background-color: #9c27b0; /* Purple color for quick registrations */
+  }
+  
+  /* Filter badge styling */
+  .filter-badge {
+    width: 8px;
+    height: 8px;
+    background-color: #e74c3c;
+    border-radius: 50%;
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+  
+  /* Filter button active state */
+  .filter-button.active {
+    background: #f0f0f0;
+    border-color: #442777;
+  }
+  
+  /* Filter panel animation */
+  @keyframes slideDown {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  
+  .filter-panel {
+    padding: 20px 30px;
+    background-color: #f8f9fa;
+    border-bottom: 1px solid #eaeaea;
+    animation: slideDown 0.3s ease;
+  }
+  
+  /* Improve the date display in cards */
+  .quick-reg-item.date-item {
+    margin-top: 8px;
+  }
+  
+  .quick-reg-item.date-item .quick-reg-value {
+    font-style: italic;
+    color: #666;
+  }
+  
+  /* Responsive styles */
+  @media (max-width: 768px) {
+    .quick-reg-content {
+      padding: 15px 20px;
+    }
+  
+    .quick-reg-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+  


### PR DESCRIPTION


I've added the "QUICK REGISTRATIONS" metric card to the ManageEvent page and created a dedicated page to view these registrations with the simplified card layout you requested. Here's what I've implemented:

1. **Added a new metric card** to the EventMetricsSection component with:

1. A purple icon using the `faUserPlus` icon
2. A count of quick registrations
3. A "View Registrations" button that navigates to the new page



2. **Created a new QuickRegistrationsList page** that:

1. Shows simplified cards with only name, email, phone, gender, and OTP
2. Has a search functionality to filter registrations
3. Uses pagination for better user experience
4. Maintains the same styling approach as the AttendeeList page



3. **Added a new route** in App.jsx for the quick registrations page:

1. `/events/:eventId/quick-registrations`



4. **Created a new CSS file** for styling the quick registrations cards with:

1. Clean, simple card layout
2. Hover effects for better interactivity
3. Responsive design for mobile devices
4. Special styling for the OTP value to make it stand out



