### PR TITLE
added toggle visibility

### DIFF
--- a/src/components/event/EventDetailsSection.jsx
+++ b/src/components/event/EventDetailsSection.jsx
@@ -15,9 +15,20 @@ import {
   faBuilding,
   faInfoCircle,
   faListAlt,
+  faEye,
+  faEyeSlash,
+  faSpinner,
 } from "@fortawesome/free-solid-svg-icons"
 
-const EventDetailsSection = ({ event, eventUrl, copyEventUrl, isEditMode, toggleEditMode, updateEventData }) => {
+const EventDetailsSection = ({
+  event,
+  eventUrl,
+  copyEventUrl,
+  isEditMode,
+  toggleEditMode,
+  updateEventData,
+  updateEventVisibility,
+}) => {
   const [editFormData, setEditFormData] = useState({
     name: "",
     startDate: "",
@@ -29,6 +40,8 @@ const EventDetailsSection = ({ event, eventUrl, copyEventUrl, isEditMode, toggle
     isOffline: false,
     description: "",
   })
+
+  const [visibilityLoading, setVisibilityLoading] = useState(false)
 
   // Update form data when event changes
   useEffect(() => {
@@ -60,6 +73,17 @@ const EventDetailsSection = ({ event, eventUrl, copyEventUrl, isEditMode, toggle
     updateEventData(editFormData)
   }
 
+  const handleVisibilityToggle = () => {
+    if (!event) return
+
+    setVisibilityLoading(true)
+
+    // Call the updateEventVisibility function passed from parent
+    updateEventVisibility(!event.visibility).finally(() => {
+      setVisibilityLoading(false)
+    })
+  }
+
   if (!event) return null
 
   return (
@@ -68,11 +92,32 @@ const EventDetailsSection = ({ event, eventUrl, copyEventUrl, isEditMode, toggle
         <h2>
           <FontAwesomeIcon icon={faInfoCircle} /> Event Details
         </h2>
-        {!isEditMode && (
-          <button className="edit-button" onClick={toggleEditMode} aria-label="Edit event details">
-            <FontAwesomeIcon icon={faEdit} /> Edit Details
-          </button>
-        )}
+        <div className="section-header-actions">
+          {/* Visibility Toggle */}
+          <div className="visibility-toggle-container">
+            <span className="visibility-label">
+              <FontAwesomeIcon icon={event.visibility ? faEye : faEyeSlash} className="visibility-icon" />
+              {event.visibility ? "Public" : "Private"}
+            </span>
+            <label className="visibility-switch">
+              <input
+                type="checkbox"
+                checked={event.visibility || false}
+                onChange={handleVisibilityToggle}
+                disabled={visibilityLoading}
+              />
+              <span className="visibility-slider">
+                {visibilityLoading && <FontAwesomeIcon icon={faSpinner} className="visibility-spinner" />}
+              </span>
+            </label>
+          </div>
+
+          {!isEditMode && (
+            <button className="edit-button" onClick={toggleEditMode} aria-label="Edit event details">
+              <FontAwesomeIcon icon={faEdit} /> Edit Details
+            </button>
+          )}
+        </div>
       </div>
 
       {isEditMode ? (

--- a/src/pages/ManageEvent.jsx
+++ b/src/pages/ManageEvent.jsx
@@ -10,6 +10,7 @@ import {
   deleteEventEvaluation,
   setCurrentEvent,
   setEditMode,
+  updateEventVisibility,
 } from "../redux/eventsSlice"
 import { fetchEventAttendees } from "../redux/attendeesSlice"
 import { fetchEventQuickRegistrations } from "../redux/quickRegistrationsSlice"
@@ -24,7 +25,7 @@ import EventDetailsSection from "../components/event/EventDetailsSection"
 import EventMetricsSection from "../components/event/EventMetricsSection"
 import EventEvaluationSection from "../components/event/EventEvaluationSection"
 import EventFeedbackSection from "../components/event/EventFeedbackSection"
-import EventImageSection from "../components/event/EventImageSection" // Add this new import
+import EventImageSection from "../components/event/EventImageSection"
 import StreamsSection from "../components/event/StreamsSection"
 import PasscodeModal from "../components/PasscodeModal"
 
@@ -85,6 +86,7 @@ function ManageEvent() {
       // We'll let the component decide when to reset
     }
   }, [dispatch, eventId, navigate, events.length, currentEventId])
+
   // Update the ManageEvent component to properly handle image updates
   // Find the useEffect that updates localEvent when event changes
   useEffect(() => {
@@ -159,6 +161,31 @@ function ManageEvent() {
       })
       .catch((error) => {
         toast.error(error || "Failed to update event")
+      })
+  }
+
+  // Add a function to handle visibility toggle
+  const handleVisibilityToggle = (newVisibility) => {
+    // Immediately update local state for UI
+    setLocalEvent((prev) => ({
+      ...prev,
+      visibility: newVisibility,
+    }))
+
+    return dispatch(updateEventVisibility({ eventId, visibility: newVisibility }))
+      .unwrap()
+      .then(() => {
+        toast.success(`Event is now ${newVisibility ? "public" : "private"}`)
+        return Promise.resolve()
+      })
+      .catch((error) => {
+        // If API call fails, revert local state
+        setLocalEvent((prev) => ({
+          ...prev,
+          visibility: !newVisibility, // Revert to previous state
+        }))
+        toast.error(error || "Failed to update visibility")
+        return Promise.reject(error)
       })
   }
 
@@ -260,6 +287,7 @@ function ManageEvent() {
         description: localEvent.description,
         evaluation: localEvent.evaluation,
         imageUrl: localEvent.image_url || null, // Ensure null if undefined
+        visibility: localEvent.visibility || false, // Add visibility with default to false
       }
     : null
 
@@ -288,6 +316,7 @@ function ManageEvent() {
           isEditMode={isEditMode}
           toggleEditMode={toggleEditMode}
           updateEventData={updateEventData}
+          updateEventVisibility={handleVisibilityToggle}
         />
 
         {/* Add the new Event Image Section */}

--- a/src/redux/eventsSlice.js
+++ b/src/redux/eventsSlice.js
@@ -39,7 +39,7 @@ export const updateEvent = createAsyncThunk(
 
       // Force a refresh of the events to ensure we have the latest data
       dispatch(fetchEvents())
-      
+
       return response.data
     } catch (error) {
       const errorMessage =
@@ -63,7 +63,7 @@ export const updateEventEvaluation = createAsyncThunk(
 
       // Force refresh of all events to get the latest data
       dispatch(fetchEvents())
-      
+
       return response.data
     } catch (error) {
       const errorMessage =
@@ -85,11 +85,39 @@ export const deleteEventEvaluation = createAsyncThunk(
 
       // Force refresh of all events to get the latest data
       dispatch(fetchEvents())
-      
+
       return response.data
     } catch (error) {
       const errorMessage =
         error.response?.data?.message || error.response?.data?.error || "Failed to delete evaluation. Please try again."
+      return rejectWithValue(errorMessage)
+    }
+  },
+)
+
+// Add a new thunk for updating event visibility
+export const updateEventVisibility = createAsyncThunk(
+  "events/updateEventVisibility",
+  async ({ eventId, visibility }, { rejectWithValue, dispatch }) => {
+    try {
+      const response = await axiosWithAuth.patch(`/api/v1/foundation_events/${eventId}`, {
+        event_id: eventId,
+        event: {
+          visibility,
+        },
+      })
+
+      // Force refresh of all events to get the latest data
+      setTimeout(() => {
+        dispatch(fetchEvents())
+      }, 500) // Small delay to ensure the API has time to process
+
+      return response.data
+    } catch (error) {
+      const errorMessage =
+        error.response?.data?.message ||
+        error.response?.data?.error ||
+        "Failed to update event visibility. Please try again."
       return rejectWithValue(errorMessage)
     }
   },
@@ -167,7 +195,7 @@ const eventsSlice = createSlice({
       if (state.currentEvent && state.currentEvent.id === action.payload.id) {
         state.currentEvent = { ...state.currentEvent, ...action.payload }
       }
-    }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -179,10 +207,10 @@ const eventsSlice = createSlice({
         state.loading = false
         state.events = action.payload
         state.filteredEvents = filterEvents(action.payload, state.searchTerm, state.filters)
-        
+
         // Also update currentEvent if it exists
         if (state.currentEvent) {
-          const updatedEvent = action.payload.find(event => event.id === state.currentEvent.id)
+          const updatedEvent = action.payload.find((event) => event.id === state.currentEvent.id)
           if (updatedEvent) {
             state.currentEvent = updatedEvent
           }
@@ -269,6 +297,28 @@ const eventsSlice = createSlice({
         state.loading = false
         state.error = action.payload
       })
+      // Add cases for updateEventVisibility
+      .addCase(updateEventVisibility.pending, (state) => {
+        state.loading = true
+        state.error = null
+      })
+      .addCase(updateEventVisibility.fulfilled, (state, action) => {
+        state.loading = false
+        // Update in events array
+        const index = state.events.findIndex((event) => event.id === action.payload.id)
+        if (index !== -1) {
+          state.events[index] = action.payload
+          state.filteredEvents = filterEvents(state.events, state.searchTerm, state.filters)
+        }
+        // Update current event
+        if (state.currentEvent && state.currentEvent.id === action.payload.id) {
+          state.currentEvent = action.payload
+        }
+      })
+      .addCase(updateEventVisibility.rejected, (state, action) => {
+        state.loading = false
+        state.error = action.payload
+      })
   },
 })
 
@@ -326,7 +376,7 @@ export const {
   setCurrentEvent,
   setEditMode,
   resetCurrentEvent,
-  updateCurrentEvent
+  updateCurrentEvent,
 } = eventsSlice.actions
 
 export default eventsSlice.reducer

--- a/src/stylesheets/manageEvent.css
+++ b/src/stylesheets/manageEvent.css
@@ -78,6 +78,104 @@ section {
   gap: 10px;
 }
 
+/* Add these styles for the visibility toggle */
+.section-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.visibility-toggle-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background-color: #f9f7ff;
+  border-radius: 20px;
+  padding: 6px 12px;
+  border: 1px solid #e0e0e0;
+  transition: all 0.2s ease;
+}
+
+.visibility-toggle-container:hover {
+  border-color: #442777;
+  box-shadow: 0 2px 8px rgba(68, 39, 119, 0.1);
+}
+
+.visibility-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+  min-width: 80px;
+}
+
+.visibility-icon {
+  color: #442777;
+}
+
+/* Toggle Switch Styling */
+.visibility-switch {
+  position: relative;
+  display: inline-block;
+  width: 46px;
+  height: 24px;
+}
+
+.visibility-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.visibility-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+  border-radius: 24px;
+}
+
+.visibility-slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .visibility-slider {
+  background-color: #442777;
+}
+
+input:focus + .visibility-slider {
+  box-shadow: 0 0 1px #442777;
+}
+
+input:checked + .visibility-slider:before {
+  transform: translateX(22px);
+}
+
+/* Spinner for loading state */
+.visibility-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-size: 14px;
+  animation: spin 1s linear infinite;
+}
+
 /* Event Details Grid */
 .event-details-grid {
   display: grid;
@@ -1418,6 +1516,9 @@ select {
   }
 }
 
+/* Add these styles at the end of your manageEvent.css file */
+
+/* Event Image Section Styles */
 .event-image-section {
   margin-bottom: 40px;
   background-color: #ffffff;
@@ -1437,9 +1538,9 @@ select {
 /* Update the event image styles to fix display issues */
 .event-image-container {
   position: relative;
-  width: 500px;
-  max-width: 500px;
-  height: 500px; /* 16:9 aspect ratio for 600px width */
+  width: 100%;
+  max-width: 600px;
+  height: 315px; /* 16:9 aspect ratio for 600px width */
   border-radius: 8px;
   overflow: hidden;
   background-color: #f9f9f9;
@@ -1453,6 +1554,7 @@ select {
 .event-image {
   width: 100%;
   height: 100%;
+  object-fit: contain; /* Changed from cover to contain */
   transition: transform 0.3s ease;
   max-width: 100%;
   max-height: 100%;
@@ -1613,8 +1715,6 @@ select {
 @media (max-width: 768px) {
   .event-image-container {
     height: 250px;
-    width: 100%;
-    max-width: 500px;
   }
 
   .image-actions {
@@ -1638,5 +1738,24 @@ select {
     width: 40px;
     height: 40px;
     font-size: 16px;
+  }
+}
+
+@media (max-width: 768px) {
+  .section-header-actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    width: 100%;
+  }
+
+  .visibility-toggle-container {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .edit-button {
+    width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION


I've implemented a visibility toggle for events that allows switching between public and private states. Here's what I've added:

### 1. Visibility Toggle in Event Details Section

- Added a stylish toggle switch in the header of the Event Details section
- The toggle shows "Public" or "Private" based on the current state
- Includes appropriate icons (eye for public, eye-slash for private)
- Shows a loading spinner during state changes


### 2. Redux Integration

- Added a new async thunk `updateEventVisibility` in the events slice
- Connected to the API endpoint `/api/v1/foundation_events/:id`
- Uses the exact payload format: `{ event_id: eventId, event: { visibility: true|false } }`
- Handles loading states and error conditions


### 3. UI/UX Enhancements

- Immediate UI feedback when toggling visibility
- Success toast messages showing the new state
- Error handling with reversion to previous state if the API call fails
- Smooth animations for state transitions



### 4. State Management

- Added visibility to the mapped event object
- Implemented optimistic updates for a snappy UI experience
- Added proper error handling to revert state if the API call fails


