### PR TITLE
fixed attendee count

### DIFF
--- a/src/components/event/EventMetricsSection.jsx
+++ b/src/components/event/EventMetricsSection.jsx
@@ -10,7 +10,7 @@ import {
   faArrowRight,
   faUserPlus,
 } from "@fortawesome/free-solid-svg-icons"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { fetchEventQuickRegistrations } from "../../redux/quickRegistrationsSlice"
 
@@ -18,13 +18,67 @@ const EventMetricsSection = ({ metrics, eventId }) => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
 
+  // Get quick registrations from Redux store
   const { quickRegistrations, loading, error } = useSelector((state) => state.quickRegistrations)
 
+  // Get attendees from Redux store
+  const { attendees } = useSelector((state) => state.attendees)
+
+  // Combined metrics state
+  const [combinedMetrics, setCombinedMetrics] = useState({
+    totalRegistered: 0,
+    totalAttendedOnline: 0,
+    totalAttendedOffline: 0,
+    totalAttendedBoth: 0,
+    totalDidNotAttend: 0,
+  })
+
+  // Fetch quick registrations when component mounts
   useEffect(() => {
     if (eventId) {
       dispatch(fetchEventQuickRegistrations(eventId))
     }
   }, [eventId, dispatch])
+
+  // Calculate combined metrics whenever attendees or quickRegistrations change
+  useEffect(() => {
+    // Start with the metrics from attendees
+    const combined = { ...metrics }
+
+    // Add metrics from quick registrations
+    if (quickRegistrations && quickRegistrations.length > 0) {
+      // Count quick registrations by attendance type
+      let onlineOnly = 0
+      let offlineOnly = 0
+      let both = 0
+      let didNotAttend = 0
+
+      quickRegistrations.forEach((reg) => {
+        // Check for both snake_case and camelCase properties
+        const attendedOnline = reg.attended_online || reg.attendedOnline
+        const attendedOffline = reg.attended_offline || reg.attendedOffline
+
+        if (attendedOnline && attendedOffline) {
+          both++
+        } else if (attendedOnline) {
+          onlineOnly++
+        } else if (attendedOffline) {
+          offlineOnly++
+        } else {
+          didNotAttend++
+        }
+      })
+
+      // Add to the combined metrics
+      combined.totalRegistered += quickRegistrations.length
+      combined.totalAttendedOnline += onlineOnly
+      combined.totalAttendedOffline += offlineOnly
+      combined.totalAttendedBoth += both
+      combined.totalDidNotAttend += didNotAttend
+    }
+
+    setCombinedMetrics(combined)
+  }, [metrics, quickRegistrations])
 
   const navigateToAttendees = (type) => {
     navigate(`/events/${eventId}/attendees/${type}`)
@@ -50,7 +104,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
           <div className="metric-content">
             <h3>Total Registered</h3>
             <p className="metric-description">Total number of users who registered for this event</p>
-            <div className="metric-value">{metrics.totalRegistered}</div>
+            <div className="metric-value">{combinedMetrics.totalRegistered}</div>
           </div>
           <button
             className="metrics-view-button"
@@ -73,7 +127,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
           <div className="metric-content">
             <h3>Total Attended Online</h3>
             <p className="metric-description">Attendees who participated remotely via stream</p>
-            <div className="metric-value">{metrics.totalAttendedOnline}</div>
+            <div className="metric-value">{combinedMetrics.totalAttendedOnline}</div>
           </div>
           <button
             className="metrics-view-button"
@@ -96,7 +150,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
           <div className="metric-content">
             <h3>Total Attended Onsite</h3>
             <p className="metric-description">Attendees who participated at the physical venue</p>
-            <div className="metric-value">{metrics.totalAttendedOffline}</div>
+            <div className="metric-value">{combinedMetrics.totalAttendedOffline}</div>
           </div>
           <button
             className="metrics-view-button"
@@ -119,7 +173,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
           <div className="metric-content">
             <h3>Total Attended Both</h3>
             <p className="metric-description">Attendees who participated both online and onsite</p>
-            <div className="metric-value">{metrics.totalAttendedBoth}</div>
+            <div className="metric-value">{combinedMetrics.totalAttendedBoth}</div>
           </div>
           <button
             className="metrics-view-button"
@@ -142,7 +196,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
           <div className="metric-content">
             <h3>Total Did Not Attend</h3>
             <p className="metric-description">Registered users who did not attend the event</p>
-            <div className="metric-value">{metrics.totalDidNotAttend}</div>
+            <div className="metric-value">{combinedMetrics.totalDidNotAttend}</div>
           </div>
           <button
             className="metrics-view-button"
@@ -158,7 +212,7 @@ const EventMetricsSection = ({ metrics, eventId }) => {
           </button>
         </div>
 
-        {/* New Quick Registrations Card with dummy data */}
+        {/* Quick Registrations Card */}
         <div className="metric-card">
           <div className="metric-icon quick-reg">
             <FontAwesomeIcon icon={faUserPlus} />

--- a/src/pages/AttendeeList.jsx
+++ b/src/pages/AttendeeList.jsx
@@ -10,178 +10,232 @@ import SearchAndFilterBar from "../components/SearchAndFilterBar"
 import Pagination from "../components/Pagination"
 import "../stylesheets/attendeeList.css"
 import { fetchEventAttendees } from "../redux/attendeesSlice"
+import { fetchEventQuickRegistrations } from "../redux/quickRegistrationsSlice"
 
 const AttendeeList = () => {
-  const { eventId, type } = useParams();
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
+  const { eventId, type } = useParams()
+  const navigate = useNavigate()
+  const dispatch = useDispatch()
 
   // Redux state
-  const { attendees, loading: reduxLoading, error, currentEventId } = useSelector((state) => state.attendees);
-  const { events } = useSelector((state) => state.events);
+  const {
+    attendees,
+    loading: attendeesLoading,
+    error: attendeesError,
+    currentEventId,
+  } = useSelector((state) => state.attendees)
+  const {
+    quickRegistrations,
+    loading: quickRegLoading,
+    error: quickRegError,
+  } = useSelector((state) => state.quickRegistrations)
+  const { events } = useSelector((state) => state.events)
 
   // Local state
-  const [filteredAttendees, setFilteredAttendees] = useState([]);
-  const [displayedAttendees, setDisplayedAttendees] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [filterActive, setFilterActive] = useState(false);
-  const [eventName, setEventName] = useState('Event Name');
-  const [dataFetched, setDataFetched] = useState(false);
+  const [combinedAttendees, setCombinedAttendees] = useState([])
+  const [filteredAttendees, setFilteredAttendees] = useState([])
+  const [displayedAttendees, setDisplayedAttendees] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [searchTerm, setSearchTerm] = useState("")
+  const [filterActive, setFilterActive] = useState(false)
+  const [eventName, setEventName] = useState("Event Name")
+  const [dataFetched, setDataFetched] = useState(false)
 
-  const [currentPage, setCurrentPage] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [totalPages, setTotalPages] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1)
+  const [itemsPerPage, setItemsPerPage] = useState(10)
+  const [totalPages, setTotalPages] = useState(1)
 
   const [filters, setFilters] = useState({
-    gender: 'all',
-    memberStatus: 'all',
-    preferredAttendance: 'all',
-    attendance: 'all',
-    familyType: 'all',
-  });
+    gender: "all",
+    memberStatus: "all",
+    preferredAttendance: "all",
+    attendance: "all",
+    familyType: "all",
+  })
 
   // Set event name
   useEffect(() => {
-    const currentEvent = events.find((event) => event.id === eventId);
+    const currentEvent = events.find((event) => event.id === eventId)
     if (currentEvent) {
-      setEventName(currentEvent.name);
+      setEventName(currentEvent.name)
     }
-  }, [eventId, events]);
+  }, [eventId, events])
 
-  // Fetch attendees if needed
+  // Fetch attendees and quick registrations if needed
   useEffect(() => {
     if (!dataFetched || currentEventId !== eventId) {
-      dispatch(fetchEventAttendees(eventId));
-      setDataFetched(true);
+      dispatch(fetchEventAttendees(eventId))
+      dispatch(fetchEventQuickRegistrations(eventId))
+      setDataFetched(true)
     }
-  }, [dispatch, eventId, dataFetched, currentEventId]);
+  }, [dispatch, eventId, dataFetched, currentEventId])
 
   // Sync local loading state
   useEffect(() => {
-    setLoading(reduxLoading);
-  }, [reduxLoading]);
+    setLoading(attendeesLoading || quickRegLoading)
+  }, [attendeesLoading, quickRegLoading])
+
+  // Combine attendees and quick registrations
+  useEffect(() => {
+    if (!attendeesLoading && !quickRegLoading) {
+      // Transform quick registrations to match attendee format
+      const transformedQuickRegs = quickRegistrations.map((reg) => ({
+        ...reg,
+        // Add camelCase properties for consistency
+        id: reg.id,
+        name: reg.name,
+        email: reg.email,
+        phone: reg.phone,
+        gender: reg.gender,
+        isMember: reg.member,
+        preferredAttendance: reg.preferred_attendance,
+        attendedOnline: reg.attended_online,
+        attendedOffline: reg.attended_offline,
+        isFamily: reg.family,
+        familyMembers: reg.family_members,
+        createdAt: reg.created_at,
+        updatedAt: reg.updated_at,
+        // Add a flag to identify the source
+        isQuickRegistration: true,
+      }))
+
+      // Add a flag to regular attendees
+      const flaggedAttendees = attendees.map((attendee) => ({
+        ...attendee,
+        isQuickRegistration: false,
+      }))
+
+      // Combine both arrays
+      setCombinedAttendees([...flaggedAttendees, ...transformedQuickRegs])
+    }
+  }, [attendees, quickRegistrations, attendeesLoading, quickRegLoading])
 
   // Apply filters
   const applyFilters = useCallback(() => {
-    if (!Array.isArray(attendees)) return [];
+    if (!Array.isArray(combinedAttendees)) return []
 
-    return attendees.filter((attendee) => {
+    return combinedAttendees.filter((attendee) => {
+      // Check for both snake_case and camelCase properties
+      const attendedOnline = attendee.attended_online || attendee.attendedOnline
+      const attendedOffline = attendee.attended_offline || attendee.attendedOffline
+
       // Filter by type (based on URL param)
-      let typeMatch = true;
+      let typeMatch = true
       switch (type) {
-        case 'online':
-          typeMatch = attendee.attendedOnline && !attendee.attendedOffline;
-          break;
-        case 'offline':
-          typeMatch = attendee.attendedOffline && !attendee.attendedOnline;
-          break;
-        case 'both':
-          typeMatch = attendee.attendedOnline && attendee.attendedOffline;
-          break;
-        case 'absent':
-          typeMatch = !attendee.attendedOnline && !attendee.attendedOffline;
-          break;
-        case 'registered':
+        case "online":
+          typeMatch = attendedOnline && !attendedOffline
+          break
+        case "offline":
+          typeMatch = attendedOffline && !attendedOnline
+          break
+        case "both":
+          typeMatch = attendedOnline && attendedOffline
+          break
+        case "absent":
+          typeMatch = !attendedOnline && !attendedOffline
+          break
+        case "registered":
         default:
-          typeMatch = true;
+          typeMatch = true
       }
-      if (!typeMatch) return false;
+      if (!typeMatch) return false
 
-      const searchLower = searchTerm.toLowerCase();
+      const searchLower = searchTerm.toLowerCase()
       const searchMatch =
-        searchTerm === '' ||
-        `${attendee.title ? attendee.title + ' ' : ''}${attendee.name}`.toLowerCase().includes(searchLower) ||
+        searchTerm === "" ||
+        `${attendee.title ? attendee.title + " " : ""}${attendee.name}`.toLowerCase().includes(searchLower) ||
         (attendee.email && attendee.email.toLowerCase().includes(searchLower)) ||
-        (attendee.phone && attendee.phone.toLowerCase().includes(searchLower));
+        (attendee.phone && attendee.phone.toLowerCase().includes(searchLower))
 
-      const genderMatch = filters.gender === 'all' || attendee.gender === filters.gender;
+      const genderMatch = filters.gender === "all" || attendee.gender === filters.gender
       const memberMatch =
-        filters.memberStatus === 'all' ||
-        (filters.memberStatus === 'yes' && attendee.isMember) ||
-        (filters.memberStatus === 'no' && !attendee.isMember);
+        filters.memberStatus === "all" ||
+        (filters.memberStatus === "yes" && (attendee.isMember || attendee.member)) ||
+        (filters.memberStatus === "no" && !(attendee.isMember || attendee.member))
 
       const preferredMatch =
-        filters.preferredAttendance === 'all' || attendee.preferredAttendance === filters.preferredAttendance;
+        filters.preferredAttendance === "all" ||
+        attendee.preferredAttendance === filters.preferredAttendance ||
+        attendee.preferred_attendance === filters.preferredAttendance
 
-      let attendanceMatch = true;
-      if (filters.attendance === 'online') {
-        attendanceMatch = attendee.attendedOnline && !attendee.attendedOffline;
-      } else if (filters.attendance === 'offline') {
-        attendanceMatch = attendee.attendedOffline && !attendee.attendedOnline;
-      } else if (filters.attendance === 'both') {
-        attendanceMatch = attendee.attendedOnline && attendee.attendedOffline;
-      } else if (filters.attendance === 'none') {
-        attendanceMatch = !attendee.attendedOnline && !attendee.attendedOffline;
+      let attendanceMatch = true
+      if (filters.attendance === "online") {
+        attendanceMatch = attendedOnline && !attendedOffline
+      } else if (filters.attendance === "offline") {
+        attendanceMatch = attendedOffline && !attendedOnline
+      } else if (filters.attendance === "both") {
+        attendanceMatch = attendedOnline && attendedOffline
+      } else if (filters.attendance === "none") {
+        attendanceMatch = !attendedOnline && !attendedOffline
       }
 
       const familyMatch =
-        filters.familyType === 'all' ||
-        (filters.familyType === 'family' && attendee.isFamily) ||
-        (filters.familyType === 'person' && !attendee.isFamily);
+        filters.familyType === "all" ||
+        (filters.familyType === "family" && (attendee.isFamily || attendee.family)) ||
+        (filters.familyType === "person" && !(attendee.isFamily || attendee.family))
 
-      return searchMatch && genderMatch && memberMatch && preferredMatch && attendanceMatch && familyMatch;
-    });
-  }, [attendees, type, searchTerm, filters]);
+      return searchMatch && genderMatch && memberMatch && preferredMatch && attendanceMatch && familyMatch
+    })
+  }, [combinedAttendees, type, searchTerm, filters])
 
   // Filter attendees when filters/search change
   useEffect(() => {
-    const filtered = applyFilters();
-    setFilteredAttendees(filtered);
-    setTotalPages(Math.max(1, Math.ceil(filtered.length / itemsPerPage)));
-    setCurrentPage(1);
-  }, [applyFilters, itemsPerPage]);
+    const filtered = applyFilters()
+    setFilteredAttendees(filtered)
+    setTotalPages(Math.max(1, Math.ceil(filtered.length / itemsPerPage)))
+    setCurrentPage(1)
+  }, [applyFilters, itemsPerPage])
 
   // Paginate results
   useEffect(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage;
-    const endIndex = startIndex + itemsPerPage;
-    setDisplayedAttendees(filteredAttendees.slice(startIndex, endIndex));
-  }, [filteredAttendees, currentPage, itemsPerPage]);
+    const startIndex = (currentPage - 1) * itemsPerPage
+    const endIndex = startIndex + itemsPerPage
+    setDisplayedAttendees(filteredAttendees.slice(startIndex, endIndex))
+  }, [filteredAttendees, currentPage, itemsPerPage])
 
   // Handlers
-  const handleBack = () => navigate(`/events/${eventId}`);
-  const toggleFilter = () => setFilterActive((prev) => !prev);
+  const handleBack = () => navigate(`/events/${eventId}`)
+  const toggleFilter = () => setFilterActive((prev) => !prev)
   const handleFilterChange = (key, value) => {
-    setFilters((prev) => ({ ...prev, [key]: value }));
-  };
+    setFilters((prev) => ({ ...prev, [key]: value }))
+  }
   const clearFilters = () => {
     setFilters({
-      gender: 'all',
-      memberStatus: 'all',
-      preferredAttendance: 'all',
-      attendance: 'all',
-      familyType: 'all',
-    });
-    setSearchTerm('');
-  };
+      gender: "all",
+      memberStatus: "all",
+      preferredAttendance: "all",
+      attendance: "all",
+      familyType: "all",
+    })
+    setSearchTerm("")
+  }
   const handlePageChange = (page) => {
-    setCurrentPage(page);
-    document.querySelector('.attendee-content')?.scrollIntoView({ behavior: 'smooth' });
-  };
+    setCurrentPage(page)
+    document.querySelector(".attendee-content")?.scrollIntoView({ behavior: "smooth" })
+  }
   const handleItemsPerPageChange = (newItemsPerPage) => {
-    setItemsPerPage(newItemsPerPage);
-  };
+    setItemsPerPage(newItemsPerPage)
+  }
 
   const getTypeLabel = () => {
     switch (type) {
-      case 'registered':
-        return 'All Registered';
-      case 'online':
-        return 'Attended Online';
-      case 'offline':
-        return 'Attended Onsite';
-      case 'both':
-        return 'Attended Both';
-      case 'absent':
-        return 'Did Not Attend';
+      case "registered":
+        return "All Registered"
+      case "online":
+        return "Attended Online"
+      case "offline":
+        return "Attended Onsite"
+      case "both":
+        return "Attended Both"
+      case "absent":
+        return "Did Not Attend"
       default:
-        return '';
+        return ""
     }
-  };
+  }
 
   // Render
-  if (loading && !error) {
+  if (loading && !attendeesError && !quickRegError) {
     return (
       <div className="attendee-list-page">
         <div className="loading-container">
@@ -189,23 +243,21 @@ const AttendeeList = () => {
           <p>Loading attendees...</p>
         </div>
       </div>
-    );
+    )
   }
 
-  if (error) {
+  if (attendeesError || quickRegError) {
     return (
       <div className="attendee-list-page">
         <div className="loading-container">
-          <p className="error-message">Error loading attendees: {error}</p>
+          <p className="error-message">Error loading attendees: {attendeesError || quickRegError}</p>
           <button className="primary-button" onClick={handleBack}>
             Back to Event
           </button>
         </div>
       </div>
-    );
+    )
   }
-
-  
 
   return (
     <div className="attendee-list-page">
@@ -241,7 +293,10 @@ const AttendeeList = () => {
             <>
               <div className="attendee-cards-grid">
                 {displayedAttendees.map((attendee) => (
-                  <AttendeeCard key={attendee.id} attendee={attendee} />
+                  <AttendeeCard
+                    key={`${attendee.isQuickRegistration ? "qr-" : ""}${attendee.id}`}
+                    attendee={attendee}
+                  />
                 ))}
               </div>
 

--- a/src/redux/attendeesSlice.js
+++ b/src/redux/attendeesSlice.js
@@ -62,7 +62,25 @@ const attendeesSlice = createSlice({
         if (action.payload.data === null || action.payload.data === undefined) {
           state.attendees = []
         } else {
-          state.attendees = action.payload.data
+          // Transform the data to ensure consistent property naming
+          state.attendees = action.payload.data.map((attendee) => ({
+            ...attendee,
+            // Ensure we have camelCase properties for consistency in the app
+            // while preserving the original snake_case properties from the API
+            id: attendee.id,
+            name: attendee.name,
+            email: attendee.email,
+            phone: attendee.phone,
+            gender: attendee.gender,
+            isMember: attendee.member,
+            preferredAttendance: attendee.preferred_attendance,
+            attendedOnline: attendee.attended_online,
+            attendedOffline: attendee.attended_offline,
+            isFamily: attendee.family,
+            familyMembers: attendee.family_members,
+            createdAt: attendee.created_at,
+            updatedAt: attendee.updated_at,
+          }))
         }
 
         state.currentEventId = action.payload.eventId // Store the current event ID
@@ -79,11 +97,14 @@ const attendeesSlice = createSlice({
         // Count different attendance types if we have attendees
         if (state.attendees.length > 0) {
           state.attendees.forEach((attendee) => {
-            if (attendee.attendedOnline && attendee.attendedOffline) {
+            if (
+              (attendee.attended_online || attendee.attendedOnline) &&
+              (attendee.attended_offline || attendee.attendedOffline)
+            ) {
               metrics.totalAttendedBoth++
-            } else if (attendee.attendedOnline) {
+            } else if (attendee.attended_online || attendee.attendedOnline) {
               metrics.totalAttendedOnline++
-            } else if (attendee.attendedOffline) {
+            } else if (attendee.attended_offline || attendee.attendedOffline) {
               metrics.totalAttendedOffline++
             } else {
               metrics.totalDidNotAttend++


### PR DESCRIPTION


I've updated the code to combine attendance data from both the attendees endpoint and the quick registrations endpoint. Here's what I've implemented:

### 1. In EventMetricsSection.jsx:

- Added a new state variable `combinedMetrics` to store the combined metrics from both data sources
- Created a useEffect hook that calculates the combined metrics whenever attendees or quickRegistrations change
- The metrics now show the total counts from both regular attendees and quick registrations
- The component now displays these combined metrics instead of just the attendees metrics


### 2. In AttendeeList.jsx:

- Added a dispatch to fetch quick registrations data alongside attendees data
- Created a new state variable `combinedAttendees` that merges both data sources
- Added a transformation step to ensure consistent property naming across both data sources
- Added a flag `isQuickRegistration` to distinguish between the two data sources
- Updated the filtering logic to work with the combined data
- Modified the loading and error handling to account for both data sources
- Added unique keys for the AttendeeCard components to prevent React key conflicts

